### PR TITLE
Fix module capitalization for Linux

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@ import VueRouter from 'vue-router';
 
 import { LoadingState } from 'src/config/loading-state';
 import Navigation from 'components/Navigation/navigation';
-import Loader from 'components/Loader/Loader';
+import Loader from 'components/Loader/loader';
 
 Vue.use(VueRouter);
 


### PR DESCRIPTION
Resolve the error Module not found: Error: Can't resolve 'components/Utils/Loader/Loader' in a Docker container